### PR TITLE
chore: change ceramic endpoint

### DIFF
--- a/.changeset/empty-geckos-smile.md
+++ b/.changeset/empty-geckos-smile.md
@@ -1,0 +1,5 @@
+---
+'@blockchain-lab-um/masca': patch
+---
+
+Transition to our dedicated Ceramic mainnet node endpoint.

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "lint:fix": "pnpm prettier --ignore-path .ci.prettierignore && pnpm nx run-many --target=lint:fix",
     "prepare": "is-ci || husky install",
     "prettier": "prettier --write .",
-    "test": "pnpm nx run-many --target=test --exclude=@0xpolygonid/js-sdk",
+    "test": "IS_TESTING=true pnpm nx run-many --target=test --exclude=@0xpolygonid/js-sdk",
     "test:ci": "pnpm nx run-many --target=test:ci --exclude=@0xpolygonid/js-sdk"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
     "lint:fix": "pnpm prettier --ignore-path .ci.prettierignore && pnpm nx run-many --target=lint:fix",
     "prepare": "is-ci || husky install",
     "prettier": "prettier --write .",
-    "test": "IS_TESTING=true pnpm nx run-many --target=test --exclude=@0xpolygonid/js-sdk",
-    "test:ci": "pnpm nx run-many --target=test:ci --exclude=@0xpolygonid/js-sdk"
+    "test": "cross-env IS_TESTING=true pnpm nx run-many --target=test --exclude=@0xpolygonid/js-sdk",
+    "test:ci": "cross-env IS_TESTING=true pnpm nx run-many --target=test:ci --exclude=@0xpolygonid/js-sdk"
   },
   "dependencies": {
     "@changesets/cli": "^2.26.2"

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -15,7 +15,7 @@
         "registry": "https://registry.npmjs.org"
       }
     },
-    "shasum": "Ng+UzVfudN2H9WdDlkzGbAyTYBxDf9SAtfxxJdDrXSU="
+    "shasum": "kqXhBa5Tsmg/FSoTdvKf+RdkQ2Y4zb3IF1d5huwbfi8="
   },
   "initialPermissions": {
     "endowment:ethereum-provider": {},

--- a/packages/snap/src/utils/ceramicUtils.ts
+++ b/packages/snap/src/utils/ceramicUtils.ts
@@ -7,12 +7,14 @@ import { DIDSession } from 'did-session';
 
 export const aliases = {
   definitions: {
-    StoredCredentials:
-      'kjzl6cwe1jw147v1tf19hxyi1q5ix5s948cfm35xp55a2cngoux776kg3ypzj3p',
+    StoredCredentials: process.env.IS_TESTING
+      ? 'kjzl6cwe1jw14a05nhefxjqb74krvxgyzdaje4jnrcaie48vw31pwxxoa7qw5z9'
+      : 'kjzl6cwe1jw147v1tf19hxyi1q5ix5s948cfm35xp55a2cngoux776kg3ypzj3p',
   },
   schemas: {
-    StoredCredentials:
-      'ceramic://k3y52l7qbv1fryl3piyoqwt5lplg02kvza59o347nfmm1ubpuywghfhg3odiqbwu8',
+    StoredCredentials: process.env.IS_TESTING
+      ? 'ceramic://k3y52l7qbv1frxl7mazhftozd9tpwugrwafoqiyuuludx7s42u7crnzc4jh9ddrls'
+      : 'ceramic://k3y52l7qbv1fryl3piyoqwt5lplg02kvza59o347nfmm1ubpuywghfhg3odiqbwu8',
   },
   tiles: {},
 };
@@ -64,7 +66,10 @@ async function authenticateWithSessionKey(state: MascaState) {
  * @returns CeramicClient - Ceramic client
  */
 export async function getCeramic(state: MascaState): Promise<CeramicClient> {
-  const ceramic = new CeramicClient('https://node2.orbis.club/');
+  const ceramicEndpoint = process.env.IS_TESTING
+    ? 'https://ceramic-clay.3boxlabs.com'
+    : 'https://ceramic.masca.io';
+  const ceramic = new CeramicClient(ceramicEndpoint);
   const did = await authenticateWithSessionKey(state);
 
   await ceramic.setDID(did);


### PR DESCRIPTION
Changes:
- [x] Utilize the Ceramic testnet in tests to prevent unnecessary strain on the mainnet.
- [x] Transition to our dedicated Ceramic mainnet node endpoint.