### PR TITLE
fix: reset session on mobile device

### DIFF
--- a/.changeset/long-ligers-brush.md
+++ b/.changeset/long-ligers-brush.md
@@ -1,0 +1,5 @@
+---
+'@blockchain-lab-um/dapp': patch
+---
+
+Reset QR Code session on mobile when trying to scan a new session.

--- a/packages/dapp/src/components/QRSessionDisplay/ConnectDeviceView.tsx
+++ b/packages/dapp/src/components/QRSessionDisplay/ConnectDeviceView.tsx
@@ -136,6 +136,14 @@ export const ConnectDeviceView = () => {
                 <Button
                   variant="primary"
                   onClick={() => {
+                    // Reset session if already set
+                    changeSession({
+                      ...session,
+                      sessionId: null,
+                      key: null,
+                      exp: null,
+                      connected: false,
+                    });
                     setIsConnectionModalOpen(true);
                   }}
                 >


### PR DESCRIPTION
- reset session on mobile device when trying to scan for a new session