### PR TITLE
docs: fix broken link to EBSI Natural Person identifiers

### DIFF
--- a/packages/docs/docs/masca/supported.md
+++ b/packages/docs/docs/masca/supported.md
@@ -7,7 +7,7 @@ sidebar_position: 6
 DID methods:
 
 - [`did:ethr`](https://github.com/decentralized-identity/ethr-did-resolver/blob/master/doc/did-method-spec.md)
-- [`did:key`](https://w3c-ccg.github.io/did-method-key/) - including `did:key` method used for creation and management of [EBSI Natural Person identifiers](https://api-pilot.ebsi.eu/docs/specs/did-methods/did-method-for-natural-person)
+- [`did:key`](https://w3c-ccg.github.io/did-method-key/) - including `did:key` method used for creation and management of [EBSI Natural Person identifiers](https://hub.ebsi.eu/vc-framework/did/did-methods/natural-person)
 - [`did:pkh`](https://github.com/w3c-ccg/did-pkh/blob/main/did-pkh-method-draft.md)
 - [`did:jwk`](https://github.com/quartzjer/did-jwk/blob/main/spec.md)
 - [`did:polygonid`](https://github.com/0xPolygonID/did-polygonid/blob/main/did-polygonid-method-draft.md)


### PR DESCRIPTION
New correct URL is: https://hub.ebsi.eu/vc-framework/did/did-methods/natural-person