### PR TITLE
fix: sepolia ethr registry address

### DIFF
--- a/packages/snap/src/veramo/Veramo.service.ts
+++ b/packages/snap/src/veramo/Veramo.service.ts
@@ -955,6 +955,7 @@ class VeramoService {
         name: 'sepolia',
         provider: new Web3Provider(ethereum as any),
         chainId: '0xaa36a7',
+        registry: '0x03d5003bf0e79c5f5223588f347eba39afbc3818',
       },
     ];
 


### PR DESCRIPTION
Closes #543 

**Overview**
The current sepolia network configuration breaks on `resolveDid`. 

**Fix**
The registry address for `sepolia` differs from the other included networks and has been provided. 

**Troubleshooting**
Invoke the `resolveDid` rpc call with a sepolia network did to test that it now resolves.

**Housekeeping**
All existing tests are still passing.  